### PR TITLE
BUG: Index-to-Alphabet Support of More Columns

### DIFF
--- a/pygsuite/__init__.py
+++ b/pygsuite/__init__.py
@@ -6,7 +6,7 @@ from pygsuite.slides import Presentation
 from pygsuite.images import ImageUploader
 from pygsuite.drive import Drive
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 __author__ = "Ethan Dickinson <ethan.dickinson@gmail.com>"
 __all__ = [
     Clients,

--- a/pygsuite/constants.py
+++ b/pygsuite/constants.py
@@ -1,9 +1,19 @@
 from os import environ, path
 
 
+# AUTH
 def get_credentials():
     dirname = path.dirname(path.dirname(__file__))
     return path.join(dirname, "credentials.json")
 
 
 CREDENTIALS = environ.get("GOOGLE_APPLICATION_CREDENTIALS") or get_credentials()
+
+# COMMON
+
+# SHEETS
+SHEETS_MAX_COLUMN_NUMBER = 18278
+
+# DOCS
+
+# SLIDES

--- a/pygsuite/sheets/helpers.py
+++ b/pygsuite/sheets/helpers.py
@@ -23,7 +23,6 @@ def index_to_alphabet(input_index: int) -> str:
 
     while input_index > 0:
         input_index, remainder = divmod(input_index - 1, 26)
-        print(input_index, remainder)
         a1_notation = ascii_uppercase[remainder] + a1_notation
 
     return a1_notation

--- a/pygsuite/sheets/helpers.py
+++ b/pygsuite/sheets/helpers.py
@@ -1,0 +1,49 @@
+# from math import floor
+from string import ascii_letters, ascii_uppercase
+
+from pygsuite.constants import SHEETS_MAX_COLUMN_NUMBER
+
+
+def index_to_alphabet(input_index: int) -> str:
+    """Method to convert integer to A1 notation.
+
+    :type input_index: int
+    :param idx: Cell index to convert.
+
+    :rtype: str
+    :returns: A1 notation of the cell.
+    """
+
+    try:
+        assert input_index <= SHEETS_MAX_COLUMN_NUMBER
+    except AssertionError:
+        raise ValueError(f"Input of column index {input_index} exceeds the maximum column number allowed of {SHEETS_MAX_COLUMN_NUMBER}.")
+
+    a1_notation = ""
+
+    while input_index > 0:
+        input_index, remainder = divmod(input_index - 1, 26)
+        print(input_index, remainder)
+        a1_notation = ascii_uppercase[remainder] + a1_notation
+
+    return a1_notation
+
+
+def alphabet_to_index(cell_ref: str) -> int:
+    """Method to convert A1 notation to an integer.
+    NOTE: This method will return zero-centered indexes,
+            despite `index_to_alphabet` taking one-centered index inputs.
+
+    :type cell_ref: str
+    :param cell_ref: A1 notation of cell to convert.
+
+    :rtype: int
+    :returns: Index notation of the cell.
+    """
+
+    idx = 0
+    for char in cell_ref:
+        if char in ascii_letters:
+            idx = idx * 26 + (ord(char.upper()) - ord("A")) + 1
+
+    return idx - 1

--- a/pygsuite/sheets/worksheet.py
+++ b/pygsuite/sheets/worksheet.py
@@ -1,5 +1,3 @@
-from math import floor
-from string import ascii_letters, ascii_uppercase
 from typing import List, Optional
 
 import pandas as pd
@@ -7,26 +5,9 @@ import re
 
 from pygsuite.common.style import Border
 from pygsuite.sheets.cell import Cell
+from pygsuite.sheets.helpers import alphabet_to_index, index_to_alphabet
 
 # INDEX_SPLITTER = re.compile('(\d+)',s)
-
-
-def index_to_alphabet(idx: int):
-    out = ""
-    count = floor(idx / 26)
-    remainder = idx % 26
-    if count:
-        out = ascii_uppercase[count - 1]
-    out += ascii_uppercase[remainder - 1]
-    return out
-
-
-def alphabet_to_index(cell_ref: str):
-    idx = 0
-    for char in cell_ref:
-        if char in ascii_letters:
-            idx = idx * 26 + (ord(char.upper()) - ord("A")) + 1
-    return idx - 1
 
 
 class Worksheet(object):

--- a/tests/test_sheets/test_helpers.py
+++ b/tests/test_sheets/test_helpers.py
@@ -1,4 +1,3 @@
-from typing import Mapping
 from pygsuite.constants import SHEETS_MAX_COLUMN_NUMBER
 from pygsuite.sheets.helpers import index_to_alphabet, alphabet_to_index
 
@@ -12,6 +11,6 @@ def test_index_to_alphabet():
 
 def test_alphabet_to_index():
 
-    assert alphabet_to_index("A") == 1
+    assert alphabet_to_index("A") == 0
     assert alphabet_to_index("ZZZ") == SHEETS_MAX_COLUMN_NUMBER - 1
     assert alphabet_to_index("CK") == 88

--- a/tests/test_sheets/test_helpers.py
+++ b/tests/test_sheets/test_helpers.py
@@ -1,0 +1,17 @@
+from typing import Mapping
+from pygsuite.constants import SHEETS_MAX_COLUMN_NUMBER
+from pygsuite.sheets.helpers import index_to_alphabet, alphabet_to_index
+
+
+def test_index_to_alphabet():
+
+    assert index_to_alphabet(1) == "A"
+    assert index_to_alphabet(SHEETS_MAX_COLUMN_NUMBER) == "ZZZ"
+    assert index_to_alphabet(89) == "CK"
+
+
+def test_alphabet_to_index():
+
+    assert alphabet_to_index("A") == 1
+    assert alphabet_to_index("ZZZ") == SHEETS_MAX_COLUMN_NUMBER - 1
+    assert alphabet_to_index("CK") == 88


### PR DESCRIPTION
# Details

The previous implementation of `index_to_alphabet()` only supported up to 702 columns (`"ZZ"`), where Google Sheets supports up to 18,278 columns (`"ZZZ"`). This PR includes a change in logic to support that functionality.

# Changes

- Revised `index_to_alphabet()` logic to support more columns input.
- Added tests for `index_to_alphabet()` and `alphabet_to_index()`.
- Moved both helper functions into a new `sheets\helpers,py` file for better access.