### PR TITLE
Catch an IndexError for the list retrieval rather than a key error

### DIFF
--- a/pygsuite/sheets/sheet.py
+++ b/pygsuite/sheets/sheet.py
@@ -128,7 +128,7 @@ class Spreadsheet(DriveObject):
         elif isinstance(key, str):
             try:
                 return [worksheet for worksheet in self.worksheets if worksheet.name == key][0]
-            except KeyError:
+            except IndexError:
                 raise KeyError(
                     "No worksheet with the title '{key}' exists. The worksheets included in your spreadsheet are: {worksheets}".format(
                         key=key, worksheets=[worksheet.name for worksheet in self.worksheets]


### PR DESCRIPTION
When retrieving a sheet form a worksheet if sheet with that name is not there, catch an IndexError, since we are retrieving from a list. 