### PR TITLE
Add supportsAllDrives to get_safe search

### DIFF
--- a/docs/tutorials/drive/file.md
+++ b/docs/tutorials/drive/file.md
@@ -144,6 +144,25 @@ print(new_or_existing.url)
     If so, you will see something like this: `No matching file found, creating file now...`
 <!-- prettier-ignore-end -->
 
+### Fetching files outside your Drive
+
+Similar to many other Drive objects and methods, use the `support_all_drives` parameter to specify a search that
+includes objects outside your personal Drive that may be shared with / created by you:
+
+```python
+from pygsuite import File
+from pygsuite.enums import MimeType
+
+new_or_existing = File.get_safe(
+    name="My Friend's Spreadsheet",
+    parent_folder_ids=["1EdtzquPnXhDNNo_gjUOJMl83Sm9BV3la"],
+    mimetype=MimeType.MS_EXCEL,
+    support_all_drives=True,
+)
+
+print(new_or_existing.url)
+```
+
 ## Copying files
 
 Coming soon!

--- a/pygsuite/__init__.py
+++ b/pygsuite/__init__.py
@@ -9,7 +9,7 @@ from pygsuite.drive.file import File
 from pygsuite.drive.folder import Folder
 from pygsuite.enums import UserType, PermissionType
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 __author__ = "Ethan Dickinson <ethan.dickinson@gmail.com>"
 __all__ = [
     "Clients",

--- a/pygsuite/drive/drive_object.py
+++ b/pygsuite/drive/drive_object.py
@@ -249,6 +249,7 @@ class DriveObject:
         exact_match: bool = True,
         parent_folder_ids: Optional[List[str]] = None,
         mimetype: Optional[Union[MimeType, str]] = None,
+        support_all_drives: bool = False,
         extra_conditions: Optional[Union[QueryString, QueryStringGroup]] = None,
         drive_client: Optional[Resource] = None,
         object_client: Optional[Resource] = None,
@@ -260,6 +261,7 @@ class DriveObject:
             exact_match (bool): Whether to only match the given name exactly, or return any name containing the string.
             parent_folder_ids (List[str]): The IDs of the parent folders which contain the file.
             mimetype (Union[GoogleMimeType, str]): A specific Google Docs type to match.
+            support_all_drives (bool): Whether or not to search both My Drives and shared drives.
             extra_conditions (Union[QueryString, QueryStringGroup]): Any additional queries to pass to the files search.
             drive_client (Resource): client connection to the Drive API used to create file.
             object_client (Resource): optional domain client (e.g. SHEETS client) used by the created object.
@@ -304,6 +306,8 @@ class DriveObject:
                 spaces="drive",
                 fields="nextPageToken, files(id, name)",
                 pageToken=None,
+                supportsAllDrives=support_all_drives,
+                includeItemsFromAllDrives=support_all_drives,
             )
             .execute()
         )


### PR DESCRIPTION
Small improvement to the `get_safe` base method of all Drive objects to support `get_safe` working for objects outside of the user (or SA)'s Drive.